### PR TITLE
fix(sync): derive delta watermark from server updated_at, not device clock

### DIFF
--- a/lib/src/sync_engine.dart
+++ b/lib/src/sync_engine.dart
@@ -415,7 +415,29 @@ class SyncEngine {
         upsertedCount++;
       }
 
-      await timestamps.set(table, DateTime.now().toUtc());
+      // Advance the delta watermark from the newest *server* `updated_at`
+      // we actually observed — never the device wall clock. Deriving it from
+      // `DateTime.now()` lets a device whose clock runs ahead of the server
+      // persist a future watermark, after which `pullSince`'s
+      // `updated_at > since` filter silently skips every row the server
+      // commits in that gap — unbounded, permanent data loss for that device.
+      // Server timestamps are the only clock the `.gt(updated_at, since)`
+      // comparison is valid against. Every row here already satisfies
+      // `updated_at > since`, so this advances the watermark monotonically.
+      DateTime? maxServerTs;
+      for (final row in rows) {
+        final ts = _extractTimestamp(row);
+        if (ts != null && (maxServerTs == null || ts.isAfter(maxServerTs))) {
+          maxServerTs = ts;
+        }
+      }
+      // If no pulled row carried a parseable `updated_at`, leave the watermark
+      // unchanged rather than guessing `now()`: worst case we re-pull these
+      // same rows next cycle (idempotent upsert), which is strictly safer than
+      // advancing past server writes we have not seen.
+      if (maxServerTs != null) {
+        await timestamps.set(table, maxServerTs);
+      }
 
       _emit(SyncPullComplete(
         timestamp: DateTime.now().toUtc(),

--- a/test/security_suite_test.dart
+++ b/test/security_suite_test.dart
@@ -1083,6 +1083,10 @@ void main() {
           () async => {'tasks': DateTime.now().toUtc()};
 
       await engine.pullAll();
+      // Flush the broadcast event stream: SyncConflict is emitted synchronously
+      // inside the delete-wins path (which has no internal await), so let its
+      // listener microtask run before asserting.
+      await Future<void>.delayed(Duration.zero);
 
       final conflicts = events.whereType<SyncConflict>().toList();
       expect(conflicts, isNotEmpty);

--- a/test/watermark_clock_skew_test.dart
+++ b/test/watermark_clock_skew_test.dart
@@ -1,0 +1,158 @@
+import 'package:test/test.dart';
+import 'package:dynos_sync/dynos_sync.dart';
+
+/// Regression test for the delta-watermark clock-skew bug.
+///
+/// `SyncEngine._pullTable` used to persist each table's watermark via
+/// `timestamps.set(table, DateTime.now().toUtc())` — the *device* wall clock.
+/// If the device clock runs ahead of the server, that future watermark makes
+/// the next `pullSince`'s `updated_at > since` filter silently skip every row
+/// the server commits in the gap: unbounded, permanent data loss.
+///
+/// The watermark must instead be derived from the newest *server* `updated_at`
+/// actually observed in the pulled rows.
+
+class _MemLocal implements LocalStore {
+  final data = <String, Map<String, dynamic>>{};
+  @override
+  Future<void> upsert(String t, String id, Map<String, dynamic> r) async =>
+      data['$t:$id'] = r;
+  @override
+  Future<void> delete(String t, String id) async => data.remove('$t:$id');
+  @override
+  Future<void> clearAll(List<String> t) async => data.clear();
+}
+
+class _NoopQueue implements QueueStore {
+  @override
+  Future<void> enqueue(SyncEntry e) async {}
+  @override
+  Future<List<SyncEntry>> getPending({int limit = 50, DateTime? now}) async =>
+      const [];
+  @override
+  Future<bool> hasPending(String t, String id) async => false;
+  @override
+  Future<Set<String>> getPendingIds(String t) async => const {};
+  @override
+  Future<List<SyncEntry>> getPendingEntries(String t, String id) async =>
+      const [];
+  @override
+  Future<void> markSynced(String id) async {}
+  @override
+  Future<void> incrementRetry(String id) async {}
+  @override
+  Future<void> setNextRetryAt(String id, DateTime at) async {}
+  @override
+  Future<void> deleteEntry(String id) async {}
+  @override
+  Future<void> purgeSynced({Duration retention = const Duration(days: 30)}) async {}
+  @override
+  Future<void> clearAll() async {}
+}
+
+class _MemTimestamps implements TimestampStore {
+  final map = <String, DateTime>{};
+  @override
+  Future<DateTime> get(String t) async =>
+      map[t] ?? DateTime.fromMillisecondsSinceEpoch(0, isUtc: true);
+  @override
+  Future<void> set(String t, DateTime ts) async => map[t] = ts;
+}
+
+/// Returns rows stamped with a fixed *server* `updated_at` well in the past,
+/// and reports a remote sync-status timestamp so `pullAll` gates the table in.
+class _ServerRemote implements RemoteStore {
+  _ServerRemote(this.serverUpdatedAt);
+  final DateTime serverUpdatedAt;
+
+  @override
+  Future<void> push(String t, String id, SyncOperation op,
+      Map<String, dynamic> d) async {}
+  @override
+  Future<void> pushBatch(List<SyncEntry> e) async {}
+
+  @override
+  Future<List<Map<String, dynamic>>> pullSince(String t, DateTime since) async {
+    // The server row is newer than `since` (epoch), so it is returned.
+    return [
+      {
+        'id': 'row-1',
+        'updated_at': serverUpdatedAt.toIso8601String(),
+        'name': 'from server',
+      },
+    ];
+  }
+
+  @override
+  Future<Map<String, DateTime>> getRemoteTimestamps() async =>
+      {'tasks': serverUpdatedAt};
+}
+
+void main() {
+  test('pull watermark is the server updated_at, never the device clock',
+      () async {
+    // Server committed the row on 2020-01-01 — far behind "now".
+    final serverTs = DateTime.utc(2020, 1, 1, 12);
+    final timestamps = _MemTimestamps();
+
+    final engine = SyncEngine(
+      local: _MemLocal(),
+      remote: _ServerRemote(serverTs),
+      queue: _NoopQueue(),
+      timestamps: timestamps,
+      tables: ['tasks'],
+    );
+
+    await engine.pullAll();
+
+    final watermark = timestamps.map['tasks'];
+    expect(watermark, isNotNull, reason: 'watermark must be advanced after a pull');
+
+    // The fix: watermark equals the server row's updated_at.
+    expect(watermark, equals(serverTs));
+
+    // Guard against regression to the device clock: a device-clock watermark
+    // would land in 2026+, decades after the server timestamp.
+    expect(
+      watermark!.isBefore(DateTime.utc(2020, 1, 2)),
+      isTrue,
+      reason: 'watermark must come from server time, not DateTime.now()',
+    );
+  });
+
+  test('watermark is left unchanged when no row carries updated_at', () async {
+    // A remote that returns a row with no parseable updated_at must not let the
+    // engine guess now() — leaving the watermark lets the row re-pull safely.
+    final timestamps = _MemTimestamps();
+    timestamps.map['tasks'] = DateTime.fromMillisecondsSinceEpoch(0, isUtc: true);
+
+    final engine = SyncEngine(
+      local: _MemLocal(),
+      remote: _NoUpdatedAtRemote(),
+      queue: _NoopQueue(),
+      timestamps: timestamps,
+      tables: ['tasks'],
+    );
+
+    await engine.pullAll();
+
+    expect(timestamps.map['tasks'],
+        equals(DateTime.fromMillisecondsSinceEpoch(0, isUtc: true)));
+  });
+}
+
+class _NoUpdatedAtRemote implements RemoteStore {
+  @override
+  Future<void> push(String t, String id, SyncOperation op,
+      Map<String, dynamic> d) async {}
+  @override
+  Future<void> pushBatch(List<SyncEntry> e) async {}
+  @override
+  Future<List<Map<String, dynamic>>> pullSince(String t, DateTime since) async =>
+      [
+        {'id': 'row-1', 'name': 'no timestamp'},
+      ];
+  @override
+  Future<Map<String, DateTime>> getRemoteTimestamps() async =>
+      {'tasks': DateTime.utc(2020, 6, 1)};
+}


### PR DESCRIPTION
## Problem

`SyncEngine._pullTable` persisted each table's delta watermark with:

```dart
await timestamps.set(table, DateTime.now().toUtc()); // device wall clock
```

The next pull filters with `updated_at > since` where `since` is that watermark. If a device's clock runs **ahead** of the server, the future watermark makes the filter silently skip every row the server commits in the gap — **unbounded, permanent data loss** for that device, with no client-side way to detect it (the client has no server-time reference).

## Fix

Derive the watermark from the newest **server** `updated_at` actually observed in the pulled rows. Every pulled row already satisfies `updated_at > since`, so the watermark still advances monotonically. If no pulled row carries a parseable `updated_at`, leave the watermark unchanged rather than guessing `now()` — worst case those rows re-pull next cycle (idempotent upsert), which is strictly safer than skipping unseen server writes.

## Tests

- **New** `test/watermark_clock_skew_test.dart` — regression suite proving the watermark equals the server `updated_at` (and is left unchanged when a row lacks a timestamp). Verified it **fails on the old device-clock code** and passes on the fix.
- `test/security_suite_test.dart` #24 — flush the broadcast event stream before asserting `SyncConflict`. The delete-wins conflict path has no internal `await`; the test had been relying on the now-removed trailing `timestamps.set` await to deliver the event. The assertion itself is unchanged.

Full suite: **216 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)